### PR TITLE
fix(node4): temporarily pin text-buffer to slap-editor/text-buffer#06fa9ed

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash": "3.10.1",
     "rc": "1.1.2",
     "slap-util": "1.0.5",
-    "text-buffer": "7.1.2",
+    "text-buffer": "slap-editor/text-buffer#06fa9ed",
     "through2": "2.0.0"
   }
 }


### PR DESCRIPTION
problem is text-buffer > serializable > get-parameter-names@1.x > goatslacker/testla#4