### PR TITLE
Update text-buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash": "3.10.1",
     "rc": "1.1.2",
     "slap-util": "1.0.5",
-    "text-buffer": "slap-editor/text-buffer#06fa9ed",
+    "text-buffer": "7.1.3",
     "through2": "2.0.0"
   }
 }


### PR DESCRIPTION
7.1.3 has fixed the npm install issue with testla.